### PR TITLE
chore: Align with main architecture after leeduckgo's merge

### DIFF
--- a/DEPLOYMENTS.md
+++ b/DEPLOYMENTS.md
@@ -13,25 +13,21 @@
 - **Solidity Version:** 0.8.18
 - **Optimizer:** Enabled (200 runs)
 
-### 📋 License Contract (Modular)
+### 📋 Legacy Contract (Deprecated)
 - **Address:** [`0xc4872863fAFA8116E02004AE2Ea4a375808da312`](https://holesky.etherscan.io/address/0xc4872863fAFA8116E02004AE2Ea4a375808da312#code)
 - **Network:** Holesky Testnet
-- **Chain ID:** 17000
-- **Verified:** ✅ Manual (via flattened source)
-- **Deployed At:** 2025-10-17
-- **Contract:** `License.sol`
-- **Solidity Version:** 0.8.20
-- **Optimizer:** Enabled (200 runs)
-- **Notes:** Fixed `struct License` → `struct LicenseTemplate` naming conflict
+- **Status:** ⚠️ Deprecated (migrated to BodhiBasedCopyright architecture)
+- **Original Contract:** `License.sol` (old modular system)
+- **Notes:** This contract is from the previous architecture. Use BodhiBasedCopyright for new deployments.
 
 ---
 
 ## 🧪 Development Environment (Localhost)
 
 ### Local Hardhat Network (Chain ID: 31337)
-- **Registry:** `0x5FbDB2315678afecb367f032d93F642f64180aa3`
-- **LicenseCenter:** `0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512`
-- **Bodhi1155:** `0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0`
+- **Bodhi System:** Use `scripts/01_deploy_bodhi_system.ts` for local deployment
+- **BodhiBasedCopyright:** Deploy using main architecture scripts
+- **Note:** Legacy contracts (Registry, LicenseCenter, Bodhi1155) have been replaced by the new architecture
 
 ---
 
@@ -42,11 +38,10 @@
 - Full source code and metadata available
 - ABI extracted and integrated into frontend
 
-### License Contract
-- ✅ Successfully verified using **manual flattened source**
-- Resolved naming conflict: `struct License` → `struct LicenseTemplate`
-- Flattened source includes OpenZeppelin dependencies (Ownable, Context)
-- Verification file: `packages/hardhat/flat/License_final.sol`
+### Legacy License Contract (Deprecated)
+- ⚠️ This was from the old modular architecture
+- Replaced by BodhiBasedCopyright in the current system
+- For reference only - use BodhiBasedCopyright for new deployments
 
 ---
 
@@ -61,7 +56,7 @@
 ### Contract Explorers
 - **BodhiBasedCopyright (Etherscan):** https://holesky.etherscan.io/address/0x73da0D133EF544B5107271A36eB30c69f84adcac#code
 - **BodhiBasedCopyright (Sourcify):** https://repo.sourcify.dev/17000/0x73da0D133EF544B5107271A36eB30c69f84adcac/
-- **License (Etherscan):** https://holesky.etherscan.io/address/0xc4872863fAFA8116E02004AE2Ea4a375808da312#code
+- **Legacy License (Etherscan - Deprecated):** https://holesky.etherscan.io/address/0xc4872863fAFA8116E02004AE2Ea4a375808da312#code
 
 ---
 
@@ -72,8 +67,8 @@
 # Navigate to hardhat directory
 cd packages/hardhat
 
-# Deploy License contract
-npx hardhat run scripts/deploy-license.ts --network holesky
+# Deploy BodhiBasedCopyright contract
+npx hardhat run scripts/deploy-bodhi-copyright.ts --network holesky
 
 # Verify contract (if not auto-verified)
 npx hardhat verify --network holesky <CONTRACT_ADDRESS>

--- a/packages/nextjs/config/deployedContracts.ts
+++ b/packages/nextjs/config/deployedContracts.ts
@@ -554,13 +554,21 @@ export const LICENSE_ABI = [
 ] as const;
 
 // ============================================
-// 🗂️ Legacy/Development Contracts (Localhost)
+// 🗂️ Legacy Contracts (Deprecated - Old Architecture)
+// ============================================
+// Note: These addresses are from the old modular architecture
+// and are kept for reference only. Use holeskyContracts for new deployments.
+export const legacyContracts = {
+  registry: "0x5FbDB2315678afecb367f032d93F642f64180aa3", // Deprecated
+  licenseCenter: "0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512", // Deprecated
+  bodhi1155: "0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0", // Deprecated
+  license: LICENSE_ADDRESS, // Deprecated - use BodhiBasedCopyright
+};
+
+// ============================================
+// 📦 Current Deployment (Recommended)
 // ============================================
 export const deployedContracts = {
-  registry: "0x5FbDB2315678afecb367f032d93F642f64180aa3",
-  licenseCenter: "0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512",
-  bodhi1155: "0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0",
-  license: LICENSE_ADDRESS,
   bodhiBasedCopyright: BODHI_BASED_COPYRIGHT_ADDRESS
 };
 


### PR DESCRIPTION
## 🎯 目的

同步 NonceGeek/main 分支在李大狗合并后的架构变更。

## 📦 主要变更

### 架构更新
- ✅ 对齐新的 BodhiBasedCopyright 架构
- ✅ 废弃旧的模块化系统（License.sol, DatasetRegistry 等）
- ✅ 更新所有引用以使用新合约结构

### 修改的文件
1. **DEPLOYMENTS.md**
   - 标记旧合约为 deprecated
   - 更新部署命令
   - 更新验证说明

2. **packages/nextjs/config/deployedContracts.ts**
   - 将旧地址移至 `legacyContracts` 对象
   - 简化 `deployedContracts` 只包含当前系统
   - 添加弃用提醒

### 当前合约结构（7 个文件）